### PR TITLE
removed test requirement for python 2.7 and django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,12 @@
 # The various combinations of python and Django we test with
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
 env:
-  - DJANGO_VER=1.8
   - DJANGO_VER=1.11
   - DJANGO_VER=2.0
-matrix:
-  exclude:
-    - python: "2.7"
-      env: DJANGO_VER=2.0
-    - python: "3.6"
-      env: DJANGO_VER=1.8
 
 install:
   - pip install tox codecov


### PR DESCRIPTION
Related PRs:
https://github.com/uisautomation/iar-backend/pull/79
https://github.com/uisautomation/lookupproxy/pull/22
https://github.com/uisautomation/sms-webapp/pull/57

closes: https://github.com/uisautomation/docs/issues/12